### PR TITLE
Change getters for cod and insurence price return string

### DIFF
--- a/src/Payment.php
+++ b/src/Payment.php
@@ -164,11 +164,11 @@ class Payment
 
 
 	/**
-	 * @return float
+	 * @return string
 	 */
-	public function getCodPrice(): float
+	public function getCodPrice(): string
 	{
-		return $this->codPrice;
+		return number_format($this->codPrice, 4, '.', '');
 	}
 
 
@@ -217,11 +217,11 @@ class Payment
 
 
 	/**
-	 * @return float
+	 * @return string
 	 */
-	public function getInsurPrice(): float
+	public function getInsurPrice(): string
 	{
-		return $this->insurPrice;
+		return number_format($this->insurPrice, 4, '.', '');
 	}
 
 


### PR DESCRIPTION
I send `(float) 2554.88999999999987` and DHL soap return to me


>The formatter threw an exception while trying to deserialize the message: There was an error while >trying to deserialize parameter http://myapi.ppl.cz/v1:Packages. The InnerException message was >'There was an error deserializing the object of type >System.Collections.Generic.List`1[[Elinkx.EpsNet.API.MyAPI.MyApiPackageIn, >Elinkx.EpsNet.API.MyAPI, Version=1.18.409.1958, Culture=neutral, PublicKeyToken=null]]. The value >'2554,89' cannot be parsed as the type 'decimal'.'. Please see InnerException for more details.


`2554,89` - not working
`2554.89` - not working
`(float) 2554.89` - not working
`(string) '2554,89'` - not working
`(string) '2554.89'` - it works